### PR TITLE
Fixing url to API Design Guide on swift.org

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ title: Welcome to Swift Internals
 
 This site hosts internal documentation for the Swift compiler and
 standard library, as well as the development version of the
-[Swift API Guidelines](https://swift.org/documentation/api-design-guidelines.html).
+[Swift API Guidelines](https://swift.org/documentation/api-design-guidelines/).
 To contribute changes, please fork the
 [GitHub repository](http://github.com/apple/swift-internals) and
 submit a pull request.


### PR DESCRIPTION
hi @dabrahams, 

this is just a small fix for a broken url :). 
