### PR TITLE
Fix API Design Guidelines Markup

### DIFF
--- a/api-design-guidelines/_api-design-guidelines.md
+++ b/api-design-guidelines/_api-design-guidelines.md
@@ -1,6 +1,6 @@
 
 <div class="info screenonly" markdown="1">
-To faciliate use as a quick reference, the details of many guidelines
+To facilitate use as a quick reference, the details of many guidelines
 can be expanded individually. Details are never hidden when this page
 is printed.
 <input type="button" id="toggle" value="Expand all details now" onClick="show_or_hide_all()" />

--- a/api-design-guidelines/_conventions.md
+++ b/api-design-guidelines/_conventions.md
@@ -245,8 +245,8 @@
     distinguished**, none should be labeled.  Well-known examples
     include `min(number1, number2)` and `zip(sequence1, sequence2)`.
 
-  * <a name="first-argument-label">**When the first argument is
-    defaulted, it should have a distinct argument label**</a>.
+  * <a name="first-argument-label"></a>**When the first argument is
+    defaulted, it should have a distinct argument label**.
 
     {{expand}}
     {{detail}}

--- a/api-design-guidelines/_naming.md
+++ b/api-design-guidelines/_naming.md
@@ -37,7 +37,7 @@
 
   {{enddetail}}
 
-* <a name="omit-needless-words">**Omit needless words.**</a>  Every word in a name should convey salient
+* <a name="omit-needless-words"></a>**Omit needless words.** Every word in a name should convey salient
   information at the use site.
 
   {{expand}}
@@ -72,7 +72,7 @@
   item for details.
   {{enddetail}}
 
-* <a name="weak-type-information">**Compensate for weak type information**</a> as needed to clarify a
+* <a name="weak-type-information"></a>**Compensate for weak type information** as needed to clarify a
   parameter's **role**.
 
   {{expand}}
@@ -162,7 +162,7 @@
 
   {{enddetail}}
 
-* <a name="boolean-assertions">Uses</a> of nonmutating **Boolean
+* <a name="boolean-assertions"></a>Uses of nonmutating **Boolean
   methods and properties should read as assertions about the
   receiver**, e.g. `x.isEmpty`, `line1.intersects(line2)`.
 


### PR DESCRIPTION
This PR fixes the markup of anchor elements (`<a>` tags) on the [API Design Guidelines page](https://swift.org/documentation/api-design-guidelines/).
