### PR TITLE
Summarize logic of summary grammar rules

### DIFF
--- a/api-design-guidelines/index.md
+++ b/api-design-guidelines/index.md
@@ -93,7 +93,9 @@ is printed.
       great summary.
 
     * **Use a single sentence fragment** if possible, ending with a
-      period.  Do not use a complete sentence.
+      period.  Do not use a complete sentence.  A summary is like 
+      a dictionary definition; it is shown in the context of the 
+      API it describes.
 
     * **Describe what a function or method *does* and what it
       *returns***, omitting null effects and `Void` returns:


### PR DESCRIPTION
The "sentence fragment" rule has been a source of confusion in previous discussions; it makes sense once explained, but it's confusing by itself. This change adds a sentence to explain what the role of the summary is, and thus why the suggested grammar is the way it is.
