### PR TITLE
Fix sentence about remove(at:).

### DIFF
--- a/api-design-guidelines/index.md
+++ b/api-design-guidelines/index.md
@@ -212,7 +212,7 @@ is printed.
   ~~~
   {:.good}
 
-  If we were to omit the word `At` from the method name, it could
+  If we were to omit the word `at` from the method signature, it could
   imply to the reader that the method searches for and removes an
   element equal to `x`, rather than using `x` to indicate the
   position of the element to remove.


### PR DESCRIPTION
The sentence described the method name without the word `At`, which was referencing the old API.

Also, a bit below we show this, which seems odd since the standard library went the other way with its naming:

```
protocol Sequence {
    associatedtype IteratorType : Iterator
}
```
