### PR TITLE
"Follow case conventions": Add a paragraph on mixed-case words.

### DIFF
--- a/api-design-guidelines/index.md
+++ b/api-design-guidelines/index.md
@@ -613,6 +613,16 @@ is printed.
   var **radar**Detector: **Radar**Scanner
   var enjoys**Scuba**Diving = true
   ~~~
+
+  Words conventionally written with mixed case (usually proper names) should be
+  uniformly downcased when used in a lowercase context, and have only the
+  first letter upcased when used in a capitalized context:
+
+  ~~~swift
+  let **tex**Renderer = **TeX**Renderer()
+  let **ipad**Enabled = supports**IPad**()
+  ~~~
+
   {{enddetail}}
 
   


### PR DESCRIPTION
Prompted by the appearance of `nan` and `signalingNaN` in [SE-0067](https://github.com/apple/swift-evolution/blob/master/proposals/0067-floating-point-protocols.md). Unfortunately, I don't think this is really non-controversial enough to just merge. I'll start a thread on swift-evolution tomorrow.

cc @dabrahams, owner and maintainer of this document.
