### PR TITLE
Expand design guidelines based on URL query parameter

### DIFF
--- a/api-design-guidelines/index.md
+++ b/api-design-guidelines/index.md
@@ -1047,6 +1047,9 @@ function show_or_hide_all(){
         button.value = 'Expand all details now';
     }
 }
+if (location.search.match(/[?&]expand=true\b/)) {
+    show_or_hide_all();
+}
 </script>
 
 


### PR DESCRIPTION
To facilitate linking to initially hidden passages in the API design guidelines, this change implements an `expand=true` query parameter that has the same effect as clicking the “Expand all details now” button. For example, it will be possible to follow a link to “[Prefer methods and properties to free functions](https://swift.org/documentation/api-design-guidelines/?expand=true#prefer-method-and-properties-to-functions)” and read about the special cases in which free functions are preferred.

A comment at the top of the document currently explains why `<details>` isn’t currently suitable. Hopefully that element can be used here once [Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/detailssummary?filter=f3f0000bf&search=details) gains support for the `<details>` element’s [`open`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#attr-open) attribute.