### PR TITLE
Correct rule for associated type name conflicts

### DIFF
--- a/api-design-guidelines/index.md
+++ b/api-design-guidelines/index.md
@@ -293,12 +293,13 @@ is printed.
   
   If an associated type is so tightly bound to its protocol constraint
   that the protocol name *is* the role, avoid collision by appending
-  `Type` to the associated type name:
+  `Protocol` to the protocol name:
   
   ~~~ swift
   protocol Sequence {
-    associatedtype Iterator**Type** : Iterator
+    associatedtype Iterator : Iterator**Protocol**
   }
+  protocol IteratorProtocol { ... }
   ~~~
   {{enddetail}}
   

--- a/api-design-guidelines/index.md
+++ b/api-design-guidelines/index.md
@@ -299,7 +299,7 @@ is printed.
   protocol Sequence {
     associatedtype Iterator : Iterator**Protocol**
   }
-  protocol IteratorProtocol { ... }
+  protocol Iterator**Protocol** { ... }
   ~~~
   {{enddetail}}
   


### PR DESCRIPTION
The API Guidelines document specifies that, when both an associated type and the protocol it's constrained to ought to have the same name, you should resolve the conflict by adding a -`Type` suffix to the associated type. This was the rule in Swift 2, but ever since SE-0023 was approved, we've been following a different pattern—adding a -`Protocol` suffix to the protocol. It appears the guidelines were never updated to reflect this change.