### PR TITLE
[SE-0285] Add `#fileID` to API Design Guidelines

### DIFF
--- a/api-design-guidelines/index.md
+++ b/api-design-guidelines/index.md
@@ -808,6 +808,12 @@ func move(from **start**: Point, to **end**: Point)
   pattern of use where methods are invoked.
   {:#parameter-with-defaults-towards-the-end}
 
+* **If your API will run in production, prefer `#fileID`** over alternatives.
+  `#fileID` saves space and protects developers’ privacy. Use `#filePath` in
+  APIs that are never run by end users (such as test helpers and scripts) if
+  the full path will simplify development workflows or be used for file I/O.
+  Use `#file` to preserve source compatibility with Swift 5.2 or earlier.
+
 ### Argument Labels
 
 ~~~swift


### PR DESCRIPTION
SE-0285 was [accepted][] with an [amendment][] to the API Design Guidelines.

[accepted]: <https://forums.swift.org/t/accepted-se-0285-ease-the-transition-to-concise-magic-file-strings/38516>
[amendment]: <https://github.com/apple/swift-evolution/blob/main/proposals/0285-ease-pound-file-transition.md#swift-api-design-guidelines-amendment>