### PR TITLE
Replaces archived and outdated documentation link with a current article

### DIFF
--- a/api-design-guidelines/index.md
+++ b/api-design-guidelines/index.md
@@ -70,7 +70,7 @@ is printed.
   
   {{expand}}
   {{detail}}
-  {% assign ref = 'https://developer.apple.com/library/prerelease/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref/' %}
+  {% assign ref = 'https://developer.apple.com/documentation/xcode/writing-symbol-documentation-in-your-source-files' %}
   {% capture SymbolDoc %}{{ref}}SymbolDocumentation.html#//apple_ref/doc/uid/TP40016497-CH51-{% endcapture %}
 
   * **Use Swift's [dialect of Markdown]({{ref}}).**


### PR DESCRIPTION
The existing link pointed to an outdated developer documentation that misleads the readers quoting an older Objective-C symbol documentation syntax. 

I've replaced it with a current article covering the syntax supported by DocC in Xcode.